### PR TITLE
Add economic dictionary and training feedback

### DIFF
--- a/dictionary.csv
+++ b/dictionary.csv
@@ -1,0 +1,5 @@
+termo,descricao
+Selic,Taxa b\u00e1sica de juros da economia brasileira.
+IPCA,\u00cdndice oficial de infla\u00e7\u00e3o do pa\u00eds.
+CDB,T\u00edtulo de renda fixa emitido por bancos.
+Copom,\u00d3rg\u00e3o do Banco Central que define a taxa Selic.

--- a/pages/2_Classificacao.py
+++ b/pages/2_Classificacao.py
@@ -1,9 +1,17 @@
 import streamlit as st
 import auth_utils
+import pandas as pd
 from database import (
     create_evaluation,
     get_news_least_classified,
 )
+
+DICT = dict(pd.read_csv('dictionary.csv').values)
+
+def show_definitions(text: str):
+    found = [t for t in DICT if t.lower() in text.lower()]
+    for term in found:
+        st.caption(f"**{term}**: {DICT[term]}")
 
 EMOTIONS = ['Não selecionado', 'Felicidade', 'Tristeza', 'Nojo', 'Raiva', 'Medo', 'Surpresa', 'Desprezo', 'Neutro']
 POLARITIES = ['Não selecionado', 'Positivo', 'Neutro', 'Negativo']
@@ -28,6 +36,7 @@ if not news:
     st.stop()
 
 st.subheader(news.headline)
+show_definitions(news.headline)
 
 sentences = [news.f1, news.f2, news.f3]
 
@@ -43,6 +52,7 @@ sentiments = []
 polarities = []
 for i, sent in enumerate(sentences, 1):
     st.text(f"Frase {i}: {sent}")
+    show_definitions(sent)
     cols = st.columns(2)
     with cols[0]: sentiments.append(select(f'Sentimento {i}', EMOTIONS, f'sent_{i}'))
     with cols[1]: polarities.append(select(f'Polaridade {i}', POLARITIES, f'pol_{i}'))


### PR DESCRIPTION
## Summary
- create `dictionary.csv` with basic economic terms
- show dictionary definitions in training and classification pages
- display correct answers after submitting a training example

## Testing
- `python -m py_compile pages/1_Treinamento.py pages/2_Classificacao.py app.py auth_utils.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_685ab4b619788322a09f3e9f42d5e654