### PR TITLE
Add course and training progress tracking

### DIFF
--- a/auth_utils.py
+++ b/auth_utils.py
@@ -55,11 +55,20 @@ def get_or_register_user() -> int:
                     "Doutorado",
                 ],
             )
+            course = st.text_input("Qual seu curso?")
             reads = st.checkbox("Você costuma ler notícias financeiras?")
             invests = st.checkbox("Você costuma investir?")
             submitted = st.form_submit_button("Confirmar Cadastro")
             if submitted:
-                user_id = create_user(email, age, gender, education, reads, invests)
+                user_id = create_user(
+                    email,
+                    age,
+                    gender,
+                    education,
+                    course,
+                    reads,
+                    invests,
+                )
                 st.success("Cadastro concluído!")
                 return user_id
             st.stop()


### PR DESCRIPTION
## Summary
- track `curso` and `qnt_class` for each user
- register unknown terms per news item
- persist training progress using `qnt_class`
- reset widgets on skip/save and handle unknown term submission

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685eb553b3488322915e1c75438ccbd5